### PR TITLE
Refactor base image handling to support both indexes and single images

### DIFF
--- a/pkg/build/base.go
+++ b/pkg/build/base.go
@@ -23,19 +23,39 @@ func getBaseImage(ctx BuildContext, baseRef string, platform Platform, keychain 
 		}, nil
 	}
 
-	ref, index, err := fetchImageIndex(ctx, baseRef, keychain)
+	ref, err := name.ParseReference(baseRef)
 	if err != nil {
-		return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image index: %w", err)
+		return nil, BaseImageMetadata{}, fmt.Errorf("failed to parse base image reference: %w", err)
 	}
-	baseDigest, err := index.Digest()
-	if err != nil {
-		return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image index digest: %w", err)
-	}
-	log.Println("Using base image:", ref.Context().Digest(baseDigest.String()))
 
-	img, err := getImageForPlatform(index, platform)
+	desc, err := remote.Get(ref, remote.WithContext(ctx.Context), remote.WithAuthFromKeychain(keychain))
 	if err != nil {
-		return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image for platform: %w", err)
+		return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image: %w", err)
+	}
+
+	log.Println("Using base image:", ref.Context().Digest(desc.Digest.String()))
+
+	var img v1.Image
+	switch {
+	case desc.MediaType.IsIndex():
+		index, err := desc.ImageIndex()
+		if err != nil {
+			return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image index: %w", err)
+		}
+		img, err = getImageForPlatform(index, platform)
+		if err != nil {
+			return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image for platform: %w", err)
+		}
+	case desc.MediaType.IsImage():
+		img, err = desc.Image()
+		if err != nil {
+			return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image: %w", err)
+		}
+		if err := verifyImagePlatform(img, platform); err != nil {
+			return nil, BaseImageMetadata{}, err
+		}
+	default:
+		return nil, BaseImageMetadata{}, fmt.Errorf("unsupported base image media type: %s", desc.MediaType)
 	}
 
 	imgDigest, err := img.Digest()
@@ -43,21 +63,10 @@ func getBaseImage(ctx BuildContext, baseRef string, platform Platform, keychain 
 		return nil, BaseImageMetadata{}, fmt.Errorf("failed to retrieve base image digest: %w", err)
 	}
 
-	metadata := BaseImageMetadata{
+	return img, BaseImageMetadata{
 		name:        ref.Context().Name(),
 		imageDigest: imgDigest.String(),
-	}
-
-	return img, metadata, nil
-}
-
-func fetchImageIndex(ctx BuildContext, src string, keychain authn.Keychain) (name.Reference, v1.ImageIndex, error) {
-	ref, err := name.ParseReference(src)
-	if err != nil {
-		return nil, nil, err
-	}
-	base, err := remote.Index(ref, remote.WithContext(ctx.Context), remote.WithAuthFromKeychain(keychain))
-	return ref, base, err
+	}, nil
 }
 
 func getImageForPlatform(index v1.ImageIndex, platform Platform) (v1.Image, error) {
@@ -85,4 +94,16 @@ func getDigestForPlatform(index v1.ImageIndex, platform Platform) (v1.Hash, erro
 	}
 
 	return v1.Hash{}, fmt.Errorf("no manifest found for platform %s", platform)
+}
+
+func verifyImagePlatform(img v1.Image, platform Platform) error {
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return fmt.Errorf("failed to read base image config: %w", err)
+	}
+	imagePlatform := Platform{OS: cfg.OS, Arch: cfg.Architecture, Variant: cfg.Variant}
+	if imagePlatform != platform {
+		return fmt.Errorf("base image platform mismatch: image is %s, requested %s", imagePlatform, platform)
+	}
+	return nil
 }

--- a/pkg/build/base_test.go
+++ b/pkg/build/base_test.go
@@ -1,9 +1,12 @@
 package build
 
 import (
+	"strings"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -87,5 +90,48 @@ func TestGetDigestForPlatformVariantMismatch(t *testing.T) {
 	_, err := getDigestForPlatform(idx, Platform{OS: "linux", Arch: "arm", Variant: "v7"})
 	if err == nil {
 		t.Fatal("expected error for variant mismatch")
+	}
+}
+
+func imageWithPlatform(t *testing.T, p Platform) v1.Image {
+	t.Helper()
+	cfg, err := empty.Image.ConfigFile()
+	if err != nil {
+		t.Fatalf("get empty config: %v", err)
+	}
+	cfg = cfg.DeepCopy()
+	cfg.OS = p.OS
+	cfg.Architecture = p.Arch
+	cfg.Variant = p.Variant
+	img, err := mutate.ConfigFile(empty.Image, cfg)
+	if err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	return img
+}
+
+func TestVerifyImagePlatformMatches(t *testing.T) {
+	p := Platform{OS: "linux", Arch: "amd64"}
+	if err := verifyImagePlatform(imageWithPlatform(t, p), p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyImagePlatformArchMismatch(t *testing.T) {
+	img := imageWithPlatform(t, Platform{OS: "linux", Arch: "amd64"})
+	err := verifyImagePlatform(img, Platform{OS: "linux", Arch: "arm64"})
+	if err == nil {
+		t.Fatal("expected platform mismatch error")
+	}
+	if !strings.Contains(err.Error(), "amd64") || !strings.Contains(err.Error(), "arm64") {
+		t.Fatalf("error should name both platforms, got: %v", err)
+	}
+}
+
+func TestVerifyImagePlatformVariantMismatch(t *testing.T) {
+	img := imageWithPlatform(t, Platform{OS: "linux", Arch: "arm", Variant: "v6"})
+	err := verifyImagePlatform(img, Platform{OS: "linux", Arch: "arm", Variant: "v7"})
+	if err == nil {
+		t.Fatal("expected variant mismatch error")
 	}
 }


### PR DESCRIPTION
## Summary
Refactored the base image retrieval logic to handle both OCI image indexes (multi-platform) and single platform images, eliminating the assumption that all base images are indexes.

## Key Changes
- **Simplified image fetching**: Replaced `fetchImageIndex()` helper with direct `remote.Get()` call that retrieves a descriptor, reducing unnecessary abstraction
- **Added media type handling**: Implemented switch statement to handle both index and image media types:
  - For indexes: extracts the image for the requested platform using existing `getImageForPlatform()` logic
  - For single images: validates the image platform matches the requested platform
- **New platform verification**: Added `verifyImagePlatform()` function to validate that single platform images match the requested platform (OS, architecture, and variant)
- **Improved error messages**: Updated error messages to be more specific about what operation failed

## Implementation Details
- The refactored code uses `remote.Get()` which returns a descriptor containing media type information, allowing runtime determination of whether the base image is an index or a single image
- Platform verification for single images prevents silent mismatches and provides clear error messages showing both the image's platform and the requested platform
- Added comprehensive test coverage for the new `verifyImagePlatform()` function including matching platforms, architecture mismatches, and variant mismatches

https://claude.ai/code/session_01UZdohQtVqmVJfcW2aPhtU7