### PR TITLE
Set platform metadata on built image config

### DIFF
--- a/pkg/build/root.go
+++ b/pkg/build/root.go
@@ -277,6 +277,10 @@ func mutateConfig(img v1.Image, spec BuildSpec, metadata BaseImageMetadata) (v1.
 	imgCfg.Container = ""
 	imgCfg.DockerVersion = ""
 
+	imgCfg.OS = spec.InjectLayer.Platform.OS
+	imgCfg.Architecture = spec.InjectLayer.Platform.Arch
+	imgCfg.Variant = spec.InjectLayer.Platform.Variant
+
 	if spec.RunAs != nil {
 		imgCfg.Config.User = *spec.RunAs
 	}

--- a/pkg/build/root_test.go
+++ b/pkg/build/root_test.go
@@ -195,6 +195,52 @@ func TestValidatePlatformSources(t *testing.T) {
 	}
 }
 
+func TestBuildImageSetsPlatformOnConfig(t *testing.T) {
+	ctx := newTestBuildContext(t)
+	srcDir := createTestSourceDir(t, map[string]string{"mybin": "x"})
+
+	spec := newScratchBuildSpec(srcDir)
+	spec.InjectLayer.Platform = Platform{OS: "linux", Arch: "amd64"}
+
+	img, err := buildImage(ctx, spec)
+	if err != nil {
+		t.Fatalf("buildImage failed: %v", err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Fatalf("ConfigFile failed: %v", err)
+	}
+	if cfg.OS != "linux" {
+		t.Fatalf("expected OS=linux, got %q", cfg.OS)
+	}
+	if cfg.Architecture != "amd64" {
+		t.Fatalf("expected Architecture=amd64, got %q", cfg.Architecture)
+	}
+	if cfg.Variant != "" {
+		t.Fatalf("expected empty Variant, got %q", cfg.Variant)
+	}
+}
+
+func TestBuildImageSetsPlatformVariantOnConfig(t *testing.T) {
+	ctx := newTestBuildContext(t)
+	srcDir := createTestSourceDir(t, map[string]string{"mybin": "x"})
+
+	spec := newScratchBuildSpec(srcDir)
+	spec.InjectLayer.Platform = Platform{OS: "linux", Arch: "arm", Variant: "v7"}
+
+	img, err := buildImage(ctx, spec)
+	if err != nil {
+		t.Fatalf("buildImage failed: %v", err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Fatalf("ConfigFile failed: %v", err)
+	}
+	if cfg.OS != "linux" || cfg.Architecture != "arm" || cfg.Variant != "v7" {
+		t.Fatalf("expected linux/arm/v7, got %s/%s/%s", cfg.OS, cfg.Architecture, cfg.Variant)
+	}
+}
+
 func TestValidatePlatformSourcesAllPresent(t *testing.T) {
 	dir := t.TempDir()
 	for _, arch := range []string{"amd64", "arm64"} {


### PR DESCRIPTION
## Summary
This change ensures that the platform information (OS, architecture, and variant) specified in the build specification is properly propagated to the built image's configuration metadata.

## Key Changes
- Modified `mutateConfig()` in `pkg/build/root.go` to set the image config's OS, Architecture, and Variant fields from the `spec.InjectLayer.Platform` values
- Added two new test cases in `pkg/build/root_test.go`:
  - `TestBuildImageSetsPlatformOnConfig`: Verifies that OS and architecture are correctly set on the image config
  - `TestBuildImageSetsPlatformVariantOnConfig`: Verifies that platform variant (e.g., "v7" for ARM) is correctly set alongside OS and architecture

## Implementation Details
The platform metadata is now set during the image configuration mutation phase, ensuring that any built image will have the correct platform information in its config file. This is important for multi-platform builds and for tools that inspect image metadata to determine compatibility.

https://claude.ai/code/session_01J1eDFGdoMEJ5JKx55p1bK3